### PR TITLE
Making Laravel version constraints more explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   },
   "require": {
-    "laravel/framework": ">=5.1"
+    "laravel/framework": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
   },
   "require-dev": {
     "orchestra/testbench": "~3.0"


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.